### PR TITLE
Fix for ... argument passing in estimate_profiles_mplus2

### DIFF
--- a/R/estimate-profiles-mplus.R
+++ b/R/estimate-profiles-mplus.R
@@ -89,10 +89,34 @@ estimate_profiles_mplus2 <-
                 gsub("  ", "\n", x)
             })
 
+        mplusObjectArgNames <-
+            c(
+                "TITLE",
+                "DATA",
+                "VARIABLE",
+                "DEFINE",
+                "MONTECARLO",
+                "MODELPOPULATION",
+                "MODELMISSING",
+                "ANALYSIS",
+                "MODEL",
+                "MODELINDIRECT",
+                "MODELCONSTRAINT",
+                "MODELTEST",
+                "MODELPRIORS",
+                "OUTPUT",
+                "SAVEDATA",
+                "PLOT",
+                "usevariables",
+                "rdata",
+                "autov",
+                "imputed"
+            )
 
+        mplusObjectArgs <- Args[which(names(Args) %in% mplusObjectArgNames)]
 
         # Create mplusObject template
-        base_object <- invisible(suppressMessages(do.call(mplusObject, Args)))
+        base_object <- invisible(suppressMessages(do.call(mplusObject, mplusObjectArgs)))
         if(ncol(df) == 1){
             base_object$VARIABLE <- paste0("NAMES = ", names(df), ";\n")
         }
@@ -201,7 +225,6 @@ estimate_profiles_mplus2 <-
                         run = 1L,
                         check = FALSE,
                         varwarnings = TRUE,
-                        Mplus_command = "Mplus",
                         writeData = "ifmissing",
                         hashfilename = TRUE,
                         ...


### PR DESCRIPTION
This fixes, or rather, monkey patches, an issue with passing `...` arguments to mplusModeler and mplusObject, as observed in issue #123. Passing `Mplus_command` now works.

Issue #123 can be used for any other issues that pop up.