### PR TITLE
Fixed straggling citation

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -16,5 +16,5 @@ citEntry(entry = "Article",
          doi          = "10.21105/joss.00978",
 
          textVersion  =
-             paste("Rosenberg, J. M., Beymer, P. N., Anderson, D. J., & Schmidt, J. A. (2018). tidyLPA: An R Package to Easily Carry Out Latent Profile Analysis (LPA) Using Open-Source or Commercial Software. Journal of Open Source Software, 3(30), 978, https://doi.org/10.21105/joss.00978")
+             paste("Rosenberg, J. M., Beymer, P. N., Anderson, D. J., Van Lissa, C. J., & Schmidt, J. A. (2018). tidyLPA: An R Package to Easily Carry Out Latent Profile Analysis (LPA) Using Open-Source or Commercial Software. Journal of Open Source Software, 3(30), 978, https://doi.org/10.21105/joss.00978")
 )


### PR DESCRIPTION
Dear Josh, the call

`> citation(package = "tidyLPA")`

Still gives the incorrect citation:

```
To cite tidyLPA in publications use:

  Rosenberg, J. M., Beymer, P. N., Anderson, D. J., & Schmidt, J. A. (2018). tidyLPA: An R Package
  to Easily Carry Out Latent Profile Analysis (LPA) Using Open-Source or Commercial Software.
  Journal of Open Source Software, 3(30), 978, https://doi.org/10.21105/joss.00978

```